### PR TITLE
devdeps: update commitlint configuration and dependencies

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  rules: {
-    'scope-enum': [2, 'always', ['deps', 'configurations']],
-  },
+  extends: ['@map-colonies/commitlint-config'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",
-        "@commitlint/config-conventional": "^19.6.0",
         "@map-colonies/commitlint-config": "^1.1.1",
         "@map-colonies/eslint-config": "^4.0.0",
         "@map-colonies/prettier-config": "^0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
+        "@map-colonies/commitlint-config": "^1.1.1",
         "@map-colonies/eslint-config": "^4.0.0",
         "@map-colonies/prettier-config": "^0.0.1",
         "@map-colonies/tsconfig": "^1.0.0",
@@ -3205,6 +3206,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@map-colonies/commitlint-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@map-colonies/commitlint-config/-/commitlint-config-1.1.1.tgz",
+      "integrity": "sha512-CzGXbec9SwpGGngZddUJ7rfZiJeUNUxLjWir1GRACjOYO19EliXF9MwVn4rOtscKQCmuaTEMOg4+21LyFdqRyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@commitlint/config-conventional": "^19.6.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@map-colonies/eslint-config": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@commitlint/config-conventional": "^19.6.0",
     "@map-colonies/eslint-config": "^4.0.0",
     "@map-colonies/prettier-config": "^0.0.1",
+    "@map-colonies/commitlint-config": "^1.1.1",
     "@types/jest": "^29.4.0",
     "@types/node": "^14.14.12",
     "commitlint": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",
-    "@commitlint/config-conventional": "^19.6.0",
     "@map-colonies/eslint-config": "^4.0.0",
     "@map-colonies/prettier-config": "^0.0.1",
     "@map-colonies/commitlint-config": "^1.1.1",


### PR DESCRIPTION
This pull request focuses on updating the commit linting configuration to align with the standards set by `@map-colonies`. The most important changes include switching the commitlint configuration and updating the dependencies in the `package.json` file.

### Changes to commit linting configuration:

* [`commitlint.config.js`](diffhunk://#diff-2b1ae4316086c0ebb213227790133a792300e1cef03b0afc067b23d3399ea5caL2-R2): Updated the configuration to extend from `@map-colonies/commitlint-config` instead of `@commitlint/config-conventional`.

### Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R51): Added `@map-colonies/commitlint-config` as a new dependency.